### PR TITLE
Fix problem with newlines on ingress

### DIFF
--- a/templates/_renders_ingress.yaml
+++ b/templates/_renders_ingress.yaml
@@ -13,14 +13,14 @@ metadata:
 {{- define "ph.ingress_spec.render" -}}
 
 spec:
-  {{ if hasKey . "tls" }}
+  {{- if hasKey . "tls" }}
   tls:
-    {{ range $tls := .tls }}
+    {{- range $tls := .tls }}
     hosts: {{ $tls.hosts | toYaml | nindent 6 }}
-
+      
     secretName: {{ $tls.secretName }}
     {{ end }}
-  {{- end -}}
+  {{ end }}
   rules: 
   {{- if hasKey . "rules" }}
 


### PR DESCRIPTION
# Motivation

There is a bug on ingress render for complex rules due to a newline not being inserted after de range loop. 

This PR fixes the problem by removing the newline exclusion. 