### PR TITLE
Add validation for tls' hosts

### DIFF
--- a/templates/_renders_ingress.yaml
+++ b/templates/_renders_ingress.yaml
@@ -15,7 +15,10 @@ metadata:
 spec:
   {{- if hasKey . "tls" }}
   tls:
-    {{- range $tls := .tls }}
+    {{ range $tls := .tls }}
+    {{ if not (kindIs "slice" $tls.hosts) }}
+    {{ fail "[Ingres:render] tls' hosts must be a list" }}
+    {{ end }}
     hosts: {{ $tls.hosts | toYaml | nindent 6 }}
       
     secretName: {{ $tls.secretName }}


### PR DESCRIPTION
from issue #14 .  

Added a validation for tls' hosts on ingress render. 

Is hosts is not a list (slice in Go internal types) the render fails. 