### PR TITLE
Feature/ingress v.18 format 

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "ph.k8s.version" -}}
+{{ .Capabilities.KubeVersion.Version }}
+{{- end -}}

--- a/templates/_renders_ingress.yaml
+++ b/templates/_renders_ingress.yaml
@@ -15,7 +15,10 @@ metadata:
 spec:
   {{- if hasKey . "tls" }}
   tls:
-    {{- range $tls := .tls }}
+    {{ range $tls := .tls }}
+    {{ if not (kindIs "slice" $tls.hosts) }}
+    {{ fail "[Ingres:render] tls' hosts must be a list" }}
+    {{ end }}
     hosts: {{ $tls.hosts | toYaml | nindent 6 }}
       
     secretName: {{ $tls.secretName }}

--- a/templates/_renders_ingress.yaml
+++ b/templates/_renders_ingress.yaml
@@ -38,7 +38,7 @@ spec:
 
 {{- define "ph.ingress_rules.single.render" }}
 
-{{ $version := (default "1.16.0" .version) }}
+{{ $version := (default "1.18.0" .version) }}
 
 {{- if semverCompare ">=1.18.0" $version -}}
 {{ include "ph.ingress_rules.single.v18+.render" . }}

--- a/templates/_renders_ingress.yaml
+++ b/templates/_renders_ingress.yaml
@@ -38,10 +38,36 @@ spec:
 
 {{- define "ph.ingress_rules.single.render" }}
 
+{{ $version := (default "1.16.0" .version) }}
+
+{{- if semverCompare ">=1.18.0" $version -}}
+{{ include "ph.ingress_rules.single.v18+.render" . }}
+{{- else -}}
+{{ include "ph.ingress_rules.single.v16+.render" . }}
+{{- end -}}
+
+{{- end -}}
+
+{{- define "ph.ingress_rules.single.v18+.render" }}
+
 paths: 
 {{ range $rule := .rules_path }}
 - path: {{ $rule.path }}
   pathType: {{ default "Prefix" $rule.pathType }}
+  backend:
+    serviceName: {{ $rule.service }}
+    servicePort: {{ $rule.port }}
+    version: {{ $.version }}
+{{ end }}
+
+{{- end -}}
+
+
+{{- define "ph.ingress_rules.single.v16+.render" }}
+
+paths: 
+{{ range $rule := .rules_path }}
+- path: {{ $rule.path }}
   backend:
     serviceName: {{ $rule.service }}
     servicePort: {{ $rule.port }}


### PR DESCRIPTION
# Motivation

from issue #14 

Due to changes on ingress format depending on kubernetes version, we need a method able to detect, according to the k8s cluster, the proper artifact to render. 

Enter the version options. 

Now, it is possible to set a version of kubernetes when defining the ingress data. 

```yaml

{{- define "my-ingress.data" }}

version: {{ include "ph.k8s.version" }}  # by using this method, the K8s version is autodetected

name: {{ .Release.Name}}-foo

# ...
{{- end -}}

# and we render normally
{{ include "ph.ingress.render" (include "my-ingress.data" . | fromYaml) }}

```
By establishing the autodetected version, prefapp-helm is able to render the proper format. 



