### PR TITLE
Add render without tls

### DIFF
--- a/templates/_renders_ingress.yaml
+++ b/templates/_renders_ingress.yaml
@@ -39,9 +39,13 @@ spec:
   rules: 
   {{- if hasKey . "rules" }}
 
-  {{- else }}
-  - host: {{ (default "*" .host) }}
+  {{- else if hasKey . "host" }}
+  - host: {{ .host }}
     http:
+    {{ include "ph.ingress_rules.single.render" . | indent 6}}
+
+  {{ else }}
+  - http:
     {{ include "ph.ingress_rules.single.render" . | indent 6}}
       
   {{- end }}


### PR DESCRIPTION
There is a bug in the current version that prevents the use of ingress render without tls. 

This PR solves the problem. 