### PR TITLE
Add option for   automountServiceAccountToken

### DIFF
--- a/templates/_renders_pod.yml
+++ b/templates/_renders_pod.yml
@@ -39,6 +39,11 @@ imagePullSecrets:
 
 volumes: {{ include "ph.pod_volumes.render" . | nindent 2 }}
 
+{{ if hasKey . "automountServiceAccountToken" }}
+automountServiceAccountToken: {{ .automountServiceAccountToken }}
+{{ end }}
+
+
 {{- end -}}
 
 {{/* Render for containers (loop) */}}


### PR DESCRIPTION
From #42 , just put this on your pod data:

```yaml
{{ define "my-pod.data" }}
   
automountServiceAccountToken: false

{{ end }}

````

To avoid having mounted the access token on your pods. 

From [this](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server).

