### PR TITLE
Establish named ports for services

### DIFF
--- a/templates/_renders_container.yaml
+++ b/templates/_renders_container.yaml
@@ -105,6 +105,7 @@ command: {{ range $a := .command }}
 {{- range $port := .ports -}}
 - containerPort: {{ $port.pod }}
   protocol: {{ default "TCP" $port.protocol }}
+  name: {{ $port.name }}
 {{end -}}
 
 {{- end -}}

--- a/templates/_renders_container.yaml
+++ b/templates/_renders_container.yaml
@@ -104,6 +104,7 @@ command: {{ range $a := .command }}
 
 {{- range $port := .ports -}}
 - containerPort: {{ $port.pod }}
+  protocol: {{ default "TCP" $port.protocol }}
 {{end -}}
 
 {{- end -}}

--- a/templates/_renders_service.yaml
+++ b/templates/_renders_service.yaml
@@ -14,9 +14,12 @@ spec:
   {{- end }}
   ports:
   {{ range $p := required $error .ports }}
-  - protocol: TCP
+  - protocol: {{ default "TCP" $p.protocol }}
     targetPort: {{ $p.pod }}
     port: {{ $p.service }}
+    {{ with $p.name }}
+    name: {{ . }}
+   {{ end }}
   {{ end -}} 
 {{- end -}}
 


### PR DESCRIPTION
Whenever there are more than one port, a named for every port is mandatory in the new specs. 

This PR resolves this problem. 