### PR TITLE
Add terminationGracePeriodSeconds and lifecyle policy

### DIFF
--- a/templates/_renders_pod.yml
+++ b/templates/_renders_pod.yml
@@ -44,6 +44,16 @@ automountServiceAccountToken: {{ .automountServiceAccountToken }}
 {{ end }}
 
 
+{{/*Lifecycle section*/}}
+{{ with .lifecycle }}
+{{ . | toYaml }}
+{{ end }}
+
+{{ if hasKey . "terminationGracePeriodSeconds" }}
+terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}
+{{ end }}
+
+
 {{- end -}}
 
 {{/* Render for containers (loop) */}}


### PR DESCRIPTION
With this PR we add:

1. A [terminationGracePeriodSeconds](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) option that can be expressed on data blocks 
2. A Pod [lifecycle](https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/) section for pod's render to work with. 

