### PR TITLE
Add pod labels to deployment's template render

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+- Add pod_labels for deployment render. 
+
 ## 0.0.8 [11-05-2021]
 
 - Fix _dict objects problem [PR](https://github.com/prefapp/prefapp-helm/pull/58).

--- a/templates/_renders_deployment.yaml
+++ b/templates/_renders_deployment.yaml
@@ -36,6 +36,9 @@ spec:
 
 metadata:
   labels: {{ include "ph.deployment.selector.render" . | nindent 4 }}
+  {{- range $k, $v := .pod_labels }}
+    {{ $k }}: {{ $v | quote }}
+  {{- end }}
   annotations:
   {{- range $k, $v := (default (dict) .pod_annotations) }}
     {{ $k }}: {{ $v | quote }}


### PR DESCRIPTION
This PR solves the problem of defining arbitrary labels for a pod at a deployment level. 

It suffises with declaring a pod_labels object and pass it to the render:

```yaml

pod_labels:
  foo: "value1"
  foo2: "value2"

```  

