### PR TITLE
Add pod-labels for cronjobs

### DIFF
--- a/templates/_renders_cronjob.yaml
+++ b/templates/_renders_cronjob.yaml
@@ -15,6 +15,13 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata: 
+          {{ with .pod_labels }}
+          labels: 
+          {{- range $k, $v := . }}
+            {{ $k }}: {{ $v | quote }}
+          {{- end }}
+          {{ end }}
         spec: {{ $spec | toYaml | nindent 10 }}
 
 {{- end -}}


### PR DESCRIPTION
This PR add pod-labels feature for cronjobs. 