### PR TITLE
Bump version 0.0.11

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.0.10
+version: 0.0.11
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+## 0.0.11 [25-05-2021]
+
+- Add specs for cronjobs as k8s v1.21. [PR](https://github.com/prefapp/prefapp-helm/pull/69).
+
 ## 0.0.10 [25-05-2021]
 
 - Add pod_labels for cronjobs. [PR](https://github.com/prefapp/prefapp-helm/pull/66).


### PR DESCRIPTION
## 0.0.11 [25-05-2021]

- Add specs for cronjobs as k8s v1.21. [PR](https://github.com/prefapp/prefapp-helm/pull/69).
