### PR TITLE
Fix problem of null on cronjob specs

### DIFF
--- a/templates/_renders_cronjob.yaml
+++ b/templates/_renders_cronjob.yaml
@@ -14,20 +14,20 @@ spec:
 
   suspend: {{ default false .suspend }}
   
-  {{ with .successfulJobsHistoryLimit }}
-  successfulJobsHistoryLimit: {{ . }}
+  {{ if hasKey . "successfulJobsHistoryLimit" }}
+  successfulJobsHistoryLimit: {{ .successfulJobsHistoryLimit }}
   {{ end }}
   
-  {{ with .failedJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ . }}
+  {{ if hasKey . "failedJobsHistoryLimit" }}
+  failedJobsHistoryLimit: {{ .failedJobsHistoryLimit }}
   {{ end }}
 
-  {{ with .startingDeadlineSeconds }}
-  startingDeadlineSeconds: {{ . }}
+  {{ if hasKey . "startingDeadlineSeconds" }}
+  startingDeadlineSeconds: {{ .startingDeadlineSeconds }}
   {{ end }}
   
-  {{ with .concurrencyPolicy }}
-  concurrencyPolicy: {{ . }}
+  {{ if hasKey . "concurrencyPolicy" }}
+  concurrencyPolicy: {{ .concurrencyPolicy }}
   {{ end }}
   
   jobTemplate:


### PR DESCRIPTION
This PR fixes the problem of null values for cronjobs specs. With statement does not work whenever a null value is used. 