### PR TITLE
Bump version 0.0.12

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.0.11
+version: 0.0.12
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+## 0.0.11 [31-05-2021]
+
+- Add strategy for deployments.  [PR](https://github.com/prefapp/prefapp-helm/pull/75).
+
 ## 0.0.11 [25-05-2021]
 
 - Add specs for cronjobs as k8s v1.21. [PR](https://github.com/prefapp/prefapp-helm/pull/69).

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-## 0.0.11 [31-05-2021]
+## 0.0.12 [31-05-2021]
 
 - Add strategy for deployments.  [PR](https://github.com/prefapp/prefapp-helm/pull/75).
 


### PR DESCRIPTION
## 0.0.12 [31-05-2021]

- Add strategy for deployments.  [PR](https://github.com/prefapp/prefapp-helm/pull/75).
