### PR TITLE
Bump version 0.0.13

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.0.12
+version: 0.0.13
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## [unreleased]
 
+## 0.0.13 [11-06-2021]
+
 - Establish 1.21 specs for cronjobs and jobs. [PR](https://github.com/prefapp/prefapp-helm/pull/78).
 
 ## 0.0.12 [31-05-2021]


### PR DESCRIPTION
## 0.0.13 [11-06-2021]

- Establish 1.21 specs for cronjobs and jobs. [PR](https://github.com/prefapp/prefapp-helm/pull/78).

