### PR TITLE
Bump version 0.0.18

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.0.17
+version: 0.0.18
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+## 0.0.18 [6-07-2021]
+
+- Prepare ingress' render to accept multiple hosts. [PR](https://github.com/prefapp/prefapp-helm/pull/97). 
+
 ## 0.0.17 [30-06-2021]
 
 - Add final augmenter


### PR DESCRIPTION
## 0.0.18 [6-07-2021]

- Prepare ingress' render to accept multiple hosts. [PR](https://github.com/prefapp/prefapp-helm/pull/97).

