### PR TITLE
Fix foced quotes on ingress rule hosts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.2.0
+version: 0.2.1-rc
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.2.1 [Released]
+## 0.2.1-rc [Release candidate]
 
-- Forced quotes on ingress rule hosts. 
+- Forced quotes on ingress rule hosts. [PR](https://github.com/prefapp/prefapp-helm/pull/111).
 
 ## 0.2.0 [13-07-2021]
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1 [Released]
+
+- Forced quotes on ingress rule hosts. 
+
 ## 0.2.0 [13-07-2021]
 
 - Adopted SemVer 2

--- a/templates/_renders_ingress.yaml
+++ b/templates/_renders_ingress.yaml
@@ -53,7 +53,7 @@ spec:
 
   {{- else if hasKey . "hosts" }}
   {{ range $host := .hosts }}
-  - host: {{ $host.host }}
+  - host: {{ $host.host | toString | quote }}
     http:
     {{ include "ph.ingress_rules.single.render" $host | indent 6}}
 


### PR DESCRIPTION
Forcing quotes on ingress rule hosts.
Wildcards can now be used (start of string with asterisk).

Sample:

```yaml
spec:
  rules:
  - host: foo.com
```

```yaml
spec:
  rules:
  - host: "foo.com"
```