### PR TITLE
New ingressClass render added

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,4 +4,4 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.2.7
+version: 0.2.8

--- a/templates/_renders_ingress.yaml
+++ b/templates/_renders_ingress.yaml
@@ -33,6 +33,9 @@ metadata:
 {{- define "ph.ingress_spec.render" -}}
 
 spec:
+  {{- if hasKey . "ingressClassName" }}
+  ingressClassName: {{ .ingressClassName }}
+  {{ end }}
   {{- if hasKey . "tls" }}
   tls:
     {{ range $tls := .tls }}

--- a/templates/_renders_ingress_class.yaml
+++ b/templates/_renders_ingress_class.yaml
@@ -1,0 +1,23 @@
+{{- define "ph.ingress_class.render" -}}
+
+
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: {{ required "A name is needed for the IngressClass!" .name }}
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: {{ .isDefault | default false | quote }}
+spec:
+  controller: {{ required "An ingressController name is required" .ingressController }}
+  parameters:
+    kind: IngressParameters
+    name: {{ .name }}
+    {{- if hasKey . "namespace"  }}
+    {{ $version := (default "1.20.0" .version) }}
+    {{- if semverCompare ">=1.22.0" $version -}}
+    scope: Namespace
+    namespace: {{ .namespace }}
+    {{ end }}
+    {{ end }}
+
+{{- end -}}


### PR DESCRIPTION
New changes introduced the possibility of defining a default ingress controller based on cluster or namespace.

Documentation:
https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-class-v1/
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingressclass-v1-networking-k8s-io

The old way of annotation: `kubernetes.io/ingress.class: ingress-nginx` overrides de new way `spec.IngressClassName`

You can now define the ingressClass like:
```
{{ define "ing_class.data"  }}
name: test-ingressclass
ingressController: nginx.org/ingress-controller
isDefault: true
namespace: test
version: "1.20.0"
{{- end }}
 
{{ include "ph.ingress_class.render" (include "ing_class.data" . | fromYaml )  }}
```

And if you do not want to use default ingressClass you can add `IngressClassName` to your ingress rule:
```
{{- define "myingress.ingress.data" -}}
name: my-ingress-rule
version: "1.20.0"
ingressClassName:  test-ingressclass
rules_path:
- path: /
  service: {{ .Release.Name }}-service
  port: 80
{{- end -}}

{{ include "ph.ingress.render" (include "myingress.ingress.data" . | fromYaml )  }}

```
