### PR TITLE
added range ports

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,4 +4,4 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.2.10
+version: 0.2.11

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.11 [21-10-2021]
+
+- Added range ports services and containers [PR](https://github.com/prefapp/prefapp-helm/pull/148)
+
 ## 0.2.10 [21-10-2021]
 
 - Added suppport for NodePort type services [PR](https://github.com/prefapp/prefapp-helm/pull/145)

--- a/templates/_renders_container.yaml
+++ b/templates/_renders_container.yaml
@@ -142,12 +142,19 @@ command: {{ range $a := .command }}
 {{- define "ph.container.ports.render" -}}
 
 {{- range $port := .ports -}}
+  {{- if hasKey $port "multiply" }}
+    {{- range $i := untilStep 0 ($port.multiply|int) 1 }}
+- containerPort: {{ add $i $port.pod}}
+  protocol: {{ default "TCP" $port.protocol }}
+    {{ end }}   
+  {{- else }}
 - containerPort: {{ $port.pod }}
   protocol: {{ default "TCP" $port.protocol }}
-  {{ with $port.name }}
+  {{- with $port.name }}
   name: {{ . }}
+  {{- end }}
   {{ end }}
-{{end -}}
+{{- end }}
 
 {{- end -}}
 

--- a/templates/_renders_container.yaml
+++ b/templates/_renders_container.yaml
@@ -142,12 +142,12 @@ command: {{ range $a := .command }}
 {{- define "ph.container.ports.render" -}}
 
 {{- range $port := .ports -}}
-  {{- if hasKey $port "multiply" }}
-    {{- range $i := untilStep 0 ($port.multiply|int) 1 }}
+  {{- if hasKey $port "range" }}
+    {{- range $i := untilStep 0 ($port.range|int) 1 }}
 - containerPort: {{ add $i $port.pod}}
   protocol: {{ default "TCP" $port.protocol }}
     {{ end }}   
-  {{- else }}
+  {{- else if not (hasKey $port "range_service")}}
 - containerPort: {{ $port.pod }}
   protocol: {{ default "TCP" $port.protocol }}
   {{- with $port.name }}

--- a/templates/_renders_container.yaml
+++ b/templates/_renders_container.yaml
@@ -147,7 +147,7 @@ command: {{ range $a := .command }}
 - containerPort: {{ add $i $port.pod}}
   protocol: {{ default "TCP" $port.protocol }}
     {{ end }}   
-  {{- else if not (hasKey $port "range_service")}}
+  {{- else }}
 - containerPort: {{ $port.pod }}
   protocol: {{ default "TCP" $port.protocol }}
   {{- with $port.name }}

--- a/templates/_renders_service.yaml
+++ b/templates/_renders_service.yaml
@@ -14,15 +14,23 @@ spec:
   {{- end }}
   ports:
   {{ range $p := required $error .ports }}
+    {{- if hasKey $p "multiply" }}
+      {{ range $i := untilStep 0 ($p.multiply|int) 1 }}
+  - protocol: {{ default "TCP" $p.protocol }}
+    targetPort: {{ add $i $p.pod }}
+    port: {{ add $i $p.service}}
+      {{ end }}
+    {{- else }}
   - protocol: {{ default "TCP" $p.protocol }}
     targetPort: {{ $p.pod }}
     port: {{ $p.service }}
     {{- if hasKey $p "nodePort" }}
     nodePort: {{ $p.nodePort }}
-    {{ end }}
-    {{ with $p.name }}
+    {{- end }}
+    {{- with $p.name }}
     name: {{ . }}
-   {{ end }}
+      {{ end }}
+   {{- end }}
   {{ end -}} 
 {{- end -}}
 

--- a/templates/_renders_service.yaml
+++ b/templates/_renders_service.yaml
@@ -14,6 +14,7 @@ spec:
   {{- end }}
   ports:
   {{ range $p := required $error .ports }}
+    {{- if hasKey $p "service" }}
     {{- if hasKey $p "multiply" }}
       {{ range $i := untilStep 0 ($p.multiply|int) 1 }}
   - protocol: {{ default "TCP" $p.protocol }}
@@ -30,6 +31,7 @@ spec:
     {{- with $p.name }}
     name: {{ . }}
       {{ end }}
+   {{- end }}
    {{- end }}
   {{ end -}} 
 {{- end -}}

--- a/templates/_renders_service.yaml
+++ b/templates/_renders_service.yaml
@@ -14,12 +14,23 @@ spec:
   {{- end }}
   ports:
   {{ range $p := required $error .ports }}
-    {{- if hasKey $p "service" }}
-    {{- if hasKey $p "multiply" }}
-      {{ range $i := untilStep 0 ($p.multiply|int) 1 }}
+    {{- if hasKey $p "range_service" }}
+      {{ range $i := untilStep 0 ($p.range_service|int) 1 }}
   - protocol: {{ default "TCP" $p.protocol }}
-    targetPort: {{ add $i $p.pod }}
+    targetPort: {{ $p.pod }}
     port: {{ add $i $p.service}}
+        {{- with $p.name }}
+    name: {{ . }}
+        {{- end }}
+      {{ end }}
+    {{- else if hasKey $p "range"}}
+      {{ range $i := untilStep 0 ($p.range|int) 1 }}
+  - protocol: {{ default "TCP" $p.protocol }}
+    targetPort: {{add $i $p.pod }}
+    port: {{ add $i $p.service}}
+        {{- with $p.name }}
+    name: {{ . }}
+        {{- end }}
       {{ end }}
     {{- else }}
   - protocol: {{ default "TCP" $p.protocol }}
@@ -31,7 +42,6 @@ spec:
     {{- with $p.name }}
     name: {{ . }}
       {{ end }}
-   {{- end }}
    {{- end }}
   {{ end -}} 
 {{- end -}}


### PR DESCRIPTION
Following issue #147:
Now you can "range" ports if you want to define a very big list of open ports in a container or service (open a lot of contiguous ports). Just add "range" to your port definition.

If you want to range service ports and match them all to the same pod port, use the "range_service" key instead.

## Example:
### values.yaml
```yaml
#values.yaml
selector:
  app: wordpress

image:  wordpress:latest

ports:
  - service: 80
    pod: 80
  - service: 40005
    pod: 40005
    protocol: UDP
    range: 3
  - service: 10000
    pod: 10000
    protocol: UDP
    range_service: 3
```

### deployment.yaml
```yaml
{{ define "wordpress.data"  }}
name: deployment-{{ .Release.Name }}-wordpress
selector:  {{ .Values.selector | toYaml | nindent 2}}
replicas: 1

serviceAccountName: {{ .Release.Name }}-svc-account
containers:
- name: {{ .Chart.Name }}
  image: {{ .Values.image }}
  ports: {{ .Values.ports | toYaml | nindent 6 }}

{{- end }}

 
{{ include "ph.deployment.render" (include "wordpress.data" . | fromYaml )  }}
 
```

```yaml
#service.yaml
{{ define "wordpress.service.data"  }}
name: {{ .Release.Name }}-service
selector:  {{ .Values.selector | toYaml | nindent 2}}
ports: {{ .Values.ports | toYaml | nindent 6 }}

{{- end }}
{{ include "ph.service.render" (include "wordpress.service.data" . | fromYaml )  }}
```
### Output
Those three files will produce the following resources:
```yaml
# helm template output
---
# Source: wordpress/templates/service.yaml
apiVersion: v1
kind: Service

metadata:
  name: RELEASE-NAME-service
spec:
  selector: 
    app: wordpress
  type: ClusterIP
  ports:
  - protocol: TCP
    targetPort: 80
    port: 80
      
  - protocol: UDP
    targetPort: 40005
    port: 40005
      
  - protocol: UDP
    targetPort: 40006
    port: 40006
      
  - protocol: UDP
    targetPort: 40007
    port: 40007
      
  - protocol: UDP
    targetPort: 10000
    port: 10000
      
  - protocol: UDP
    targetPort: 10000
    port: 10001
      
  - protocol: UDP
    targetPort: 10000
    port: 10002

---
# Source: wordpress/templates/deployment.yaml
kind: Deployment
apiVersion: apps/v1

metadata:
  name: deployment-RELEASE-NAME-wordpress

spec:
  replicas: 1
  selector: 
    matchLabels: 
      app: wordpress
  template: 
    metadata:
      labels: 
        app: wordpress
      annotations:
    spec: 
      containers: 
          - name: wordpress
            image: "wordpress:latest"
            imagePullPolicy: IfNotPresent
            env: 
            envFrom: 
            ports: 
            
            - containerPort: 80
              protocol: TCP
              
            - containerPort: 40005
              protocol: UDP
                
            - containerPort: 40006
              protocol: UDP
                
            - containerPort: 40007
              protocol: UDP
                
            volumeMounts: 
            resources: 
              requests: 
                  {}
              limits: 
                  {} 
      serviceAccountName: RELEASE-NAME-svc-account
      imagePullSecrets: 
      volumes: