### PR TITLE
Ability to set replicas to zero

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,4 +4,4 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.2.11
+version: 0.2.12

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.2.11 [21-10-2021]
+## 0.2.12 [19-11-2021]
+
+- Fixed replicas to allow 0 but not by default [PR](https://github.com/prefapp/prefapp-helm/pull/)
+
+
+## 0.2.11 [18-11-2021]
 
 - Added range ports services and containers [PR](https://github.com/prefapp/prefapp-helm/pull/148)
 

--- a/templates/_renders_deployment.yaml
+++ b/templates/_renders_deployment.yaml
@@ -17,7 +17,7 @@ apiVersion: apps/v1
 {{- define "ph.deployment.spec.render" -}}
 
 spec:
-  replicas: {{ (default 1 .replicas) }}
+  replicas: {{ if eq (toString .replicas) "0" }} {{ .replicas }} {{ else }} {{ (default 1 .replicas) }} {{ end }}
   selector: 
     matchLabels: {{ include "ph.deployment.selector.render" . | nindent 6}}
   template: {{ include "ph.deployment.template.render" . | nindent 4 }}   


### PR DESCRIPTION
Up until now the "default" would not let you set a deployment's replicas to zero.