### PR TITLE
Pass version to host render

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,4 +4,4 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.2.12
+version: 0.2.13

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.13 [29-12-2021]
+
+- Fixed problem on K8s version passed to ingress render [PR](https://github.com/prefapp/prefapp-helm/pull/154).
+
 ## 0.2.12 [19-11-2021]
 
 - Fixed replicas to allow 0 but not by default [PR](https://github.com/prefapp/prefapp-helm/pull/)

--- a/templates/_renders_ingress.yaml
+++ b/templates/_renders_ingress.yaml
@@ -58,7 +58,7 @@ spec:
   {{ range $host := .hosts }}
   - host: {{ $host.host | toString | quote }}
     http:
-    {{ include "ph.ingress_rules.single.render" $host | indent 6}}
+    {{ include "ph.ingress_rules.single.render" (merge $host (dict "version" .version)) | indent 6}}
 
   {{ end }}
   {{ else }}


### PR DESCRIPTION
This PR fixes a problem we have with multihosts. 

Whenever a .hosts is passed to the ingress render, it is mandatory to define for every host a service, a port and a path. Thus:

```yaml
hosts:
  - host: a.com
    path: /
    service: my-service
    port: 80
```

But there is a bug in the render that makes necessary to also pass the version for every host in the array. This PR fixes the problem. 