### PR TITLE
Pass to lowercase default slot

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,4 +4,4 @@ description: Prefapp's library chart for applications
 
 type: library
 
-version: 0.3.2
+version: 0.3.3

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.3 [10-01-2022]
+
+- Lowercase for Default slot. [PR](https://github.com/prefapp/prefapp-helm/pull/159).
+
 ## 0.3.2 [06-01-2022]
 
 - Add Multi-slots support for services and ingress [Experimental] [PR](https://github.com/prefapp/prefapp-helm/pull/157).

--- a/templates/_renders_deployment_multislot.yaml
+++ b/templates/_renders_deployment_multislot.yaml
@@ -22,7 +22,7 @@
 ---
 {{ $_ := set $ctx.Values "Slot" $ctx.Values }}
 
-{{ $_ := set $ctx.Values.Slot "Name" "Default" }}
+{{ $_ := set $ctx.Values.Slot "Name" "default" }}
 
 {{ if $override }}
 {{ include $render (include "ph.override" (list $datablock $ctx ) | fromYaml ) }}


### PR DESCRIPTION
Default slot with a capital "D" is against the naming rules of k8s. Thus, we lowercase the name. 