### PR TITLE
Add adaptation to autoscaler

### DIFF
--- a/templates/_renders_hpa.yaml
+++ b/templates/_renders_hpa.yaml
@@ -34,5 +34,9 @@ spec:
   minReplicas: {{ default 1 .minReplicas }}
   maxReplicas: {{ required "A maxReplicas is required for a hpa!" .maxReplicas }}
   metrics: {{ $metrics | toYaml | nindent 4 }}
+  {{ with .behavior }}
+  behavior: {{ . | toYaml | nindent 4 }}
+  {{ end }}
+
 
 {{- end -}}

--- a/templates/_renders_hpa.yaml
+++ b/templates/_renders_hpa.yaml
@@ -9,9 +9,15 @@
 
 {{ $scaleTargetRef := required "An scaleTargetRef is required for a hpa!" .scaleTargetRef }}
 
-kind: HorizontalPodAutoscaler
-apiVersion: autoscaling/v2beta2
+{{ $version := default "1.25.0" .version }}
 
+{{- if semverCompare ">=1.26.0" $version }}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta2
+{{- end }}
+
+kind: HorizontalPodAutoscaler
 metadata:
   name: {{ required "A name is required for a hpa!" .name }}
   labels: 
@@ -28,8 +34,5 @@ spec:
   minReplicas: {{ default 1 .minReplicas }}
   maxReplicas: {{ required "A maxReplicas is required for a hpa!" .maxReplicas }}
   metrics: {{ $metrics | toYaml | nindent 4 }}
-  {{ with .behavior }}
-  behavior: {{ . | toYaml | nindent 4 }}
-  {{ end }}
 
 {{- end -}}


### PR DESCRIPTION
fixes #204 

In order to autodetect the version of kubernetes you can put in your data section:

```yaml

{{ define "my-hpa.data" }}

version: {{ .Capabilities.KubeVersion.Version }}

# rest of the definitions...

{{ end }}

```
